### PR TITLE
Removing dbg!() macro call from is_symmetric()

### DIFF
--- a/src/shadowcast.rs
+++ b/src/shadowcast.rs
@@ -170,9 +170,6 @@ fn is_symmetric(row: Row, tile: Pos) -> bool {
     let col_rat = Rational::new(col, 1);
 
     let symmetric = col_rat >= depth_times_start && col_rat <= depth_times_end;
-    if tile == (6, 0) {
-        dbg!(symmetric);
-    }
 
     return symmetric;
 }


### PR DESCRIPTION
Hi.
Thank you for making this shadowcasting crate.

I've decided to rely on it in development of a small game and noticed that some debug output appeared in the log every time a call to `compute_fov()` was made. It appears to be coming from the `dbg!()` call in `is_symmetric()`, which I assume is a left-over from the time you were debugging the algorithm implementation before publishing the crate.

So here's a tiny pull request to remove this debug output.
Thanks!